### PR TITLE
Guarantee that a type is always passed to the server

### DIFF
--- a/LDSAnnotations/SyncAnnotationsOperation.swift
+++ b/LDSAnnotations/SyncAnnotationsOperation.swift
@@ -139,8 +139,8 @@ class SyncAnnotationsOperation: Operation {
                 "timestamp": annotation.lastModified.formattedISO8601,
             ]
             
-            if annotation.status == .Active {
-                result["annotation"] = annotation.jsonObject(annotationStore)
+            if annotation.status == .Active, let jsonObject = annotation.jsonObject(annotationStore) {
+                result["annotation"] = jsonObject
             }
             
             return result


### PR DESCRIPTION
This catches a case where an annotation is a journal type, but isn't attached to a notebook anymore.