### PR TITLE
Skip annotations that have invalid highlights, links, notes, etc

### DIFF
--- a/LDSAnnotations/AnnotationStore.swift
+++ b/LDSAnnotations/AnnotationStore.swift
@@ -151,6 +151,5 @@ public class AnnotationStore {
             }
         }
     }
-
     
 }

--- a/LDSAnnotations/Error.swift
+++ b/LDSAnnotations/Error.swift
@@ -41,6 +41,7 @@ public struct Error {
         case SaveHighlightFailed = -3001
         case RequiredFieldMissing = -3008
         case SyncFailed = -4000
+        case SyncDeserializationFailed = -4001
     }
     
     static func errorWithCode(code: Error.Code, failureReason: String) -> NSError {

--- a/LDSAnnotations/Error.swift
+++ b/LDSAnnotations/Error.swift
@@ -31,12 +31,6 @@ public struct Error {
         case AuthenticationFailed = -1001
         case LockedOut = -1002
         case PasswordExpired = -1003
-        case InvalidParagraphAID = -2000
-        case InvalidHighlight = -2001
-        case InvalidLink = -2002
-        case InvalidBookmark = -2003
-        case InvalidNote = -2004
-        case InvalidTag = -2005
         case SaveAnnotationFailed = -3000
         case SaveHighlightFailed = -3001
         case RequiredFieldMissing = -3008

--- a/LDSAnnotations/Session.swift
+++ b/LDSAnnotations/Session.swift
@@ -114,10 +114,10 @@ public class Session: NSObject {
         
         let syncNotebooksOperation = SyncNotebooksOperation(session: self, annotationStore: annotationStore, localSyncNotebooksDate: token?.localSyncNotebooksDate, serverSyncNotebooksDate: token?.serverSyncNotebooksDate) { syncNotebooksResult in
             switch syncNotebooksResult {
-            case let .Success(localSyncNotebooksDate: localSyncNotebooksDate, serverSyncNotebooksDate: serverSyncNotebooksDate, changes: syncNotebooksChanges):
+            case let .Success(localSyncNotebooksDate: localSyncNotebooksDate, serverSyncNotebooksDate: serverSyncNotebooksDate, changes: syncNotebooksChanges, deserializationErrors: syncNotebooksDeserializationErrors):
                 let syncAnnotationsOperation = SyncAnnotationsOperation(session: self, annotationStore: annotationStore, notebookAnnotationIDs: syncNotebooksChanges.notebookAnnotationIDs, localSyncAnnotationsDate: token?.localSyncAnnotationsDate, serverSyncAnnotationsDate: token?.serverSyncAnnotationsDate) { syncAnnotationsResult in
                     switch syncAnnotationsResult {
-                    case let .Success(localSyncAnnotationsDate: localSyncAnnotationsDate, serverSyncAnnotationsDate: serverSyncAnnotationsDate, changes: syncAnnotationsChanges):
+                    case let .Success(localSyncAnnotationsDate: localSyncAnnotationsDate, serverSyncAnnotationsDate: serverSyncAnnotationsDate, changes: syncAnnotationsChanges, deserializationErrors: syncAnnotationsDeserializationErrors):
                         let token = SyncToken(localSyncNotebooksDate: localSyncNotebooksDate, serverSyncNotebooksDate: serverSyncNotebooksDate, localSyncAnnotationsDate: localSyncAnnotationsDate, serverSyncAnnotationsDate: serverSyncAnnotationsDate)
                         let changes = SyncChanges(
                             uploadedNotebooks: syncNotebooksChanges.uploadedNotebooks,
@@ -135,7 +135,7 @@ public class Session: NSObject {
                             downloadTagCount: syncAnnotationsChanges.downloadTagCount,
                             downloadLinkCount: syncAnnotationsChanges.downloadLinkCount)
                         self.status = .SyncSuccessful
-                        completion(SyncResult.Success(token: token, changes: changes))
+                        completion(SyncResult.Success(token: token, changes: changes, deserializationErrors: (syncNotebooksDeserializationErrors + syncAnnotationsDeserializationErrors)))
                     case let .Error(errors: errors):
                         self.status = .SyncFailed
                         completion(SyncResult.Error(errors: errors))

--- a/LDSAnnotations/SyncAnnotationsOperation.swift
+++ b/LDSAnnotations/SyncAnnotationsOperation.swift
@@ -47,6 +47,7 @@ class SyncAnnotationsOperation: Operation {
     var downloadNoteCount = 0
     var downloadLinkCount = 0
     var downloadTagCount = 0
+    var deserializationErrors = [NSError]()
     
     init(session: Session, annotationStore: AnnotationStore, notebookAnnotationIDs: [String: [String]], localSyncAnnotationsDate: NSDate?, serverSyncAnnotationsDate: NSDate?, completion: (SyncAnnotationsResult) -> Void) {
         self.session = session
@@ -72,7 +73,7 @@ class SyncAnnotationsOperation: Operation {
                     downloadHighlightCount: self.downloadHighlightCount,
                     downloadTagCount: self.downloadTagCount,
                     downloadLinkCount: self.downloadLinkCount)
-                completion(.Success(localSyncAnnotationsDate: localSyncAnnotationsDate, serverSyncAnnotationsDate: serverSyncAnnotationsDate, changes: changes))
+                completion(.Success(localSyncAnnotationsDate: localSyncAnnotationsDate, serverSyncAnnotationsDate: serverSyncAnnotationsDate, changes: changes, deserializationErrors: self.deserializationErrors))
             } else {
                 completion(.Error(errors: errors))
             }
@@ -253,7 +254,7 @@ class SyncAnnotationsOperation: Operation {
                 guard let device = rawAnnotation["device"] as? String else {
                     throw Error.errorWithCode(.Unknown, failureReason: "`device` is a required field, the service returned a nil value")
                 }
-                
+
                 switch changeType {
                 case .New:
                     let iso639_3Code = rawAnnotation["@locale"] as? String ?? "eng"
@@ -262,181 +263,176 @@ class SyncAnnotationsOperation: Operation {
                     let created = (rawAnnotation["created"] as? String).flatMap { NSDate.parseFormattedISO8601($0) }
                     let status = (rawAnnotation["@status"] as? String).flatMap { AnnotationStatus(rawValue: $0) } ?? .Active
                     
-                    let databaseAnnotation: Annotation?
-                    if var existingAnnotation = annotationStore.annotationWithUniqueID(uniqueID) {
-                        existingAnnotation.iso639_3Code = iso639_3Code
-                        existingAnnotation.source = source
-                        existingAnnotation.device = device
-                        existingAnnotation.docID = docID
-                        existingAnnotation.docVersion = docVersion
-                        existingAnnotation.created = created
-                        existingAnnotation.lastModified = lastModified
-                        existingAnnotation.status = status
-                        databaseAnnotation = try annotationStore.updateAnnotation(existingAnnotation, inSync: true)
-                    } else {
-                        databaseAnnotation = try annotationStore.addAnnotation(uniqueID: uniqueID, iso639_3Code: iso639_3Code, docID: docID, docVersion: docVersion, created: created, lastModified: lastModified, source: source, device: device, inSync: true)
-                    }
-                    downloadAnnotationCount += 1
-                    
-                    if let annotationID = databaseAnnotation?.id, annotationUniqueID = databaseAnnotation?.uniqueID {
-                        
-                        // MARK: Note
-                        
-                        if let note = rawAnnotation["note"] as? [String: AnyObject] {
-                            let title = note["title"] as? String
-                            let content = note["content"] as? String ?? ""
-                            if var existingNote = annotationStore.noteWithAnnotationID(annotationID) {
-                                existingNote.title = title
-                                existingNote.content = content
-                                try annotationStore.updateNote(existingNote)
+                    do {
+                        try annotationStore.db.savepoint {
+                            let databaseAnnotation: Annotation?
+                            if var existingAnnotation = self.annotationStore.annotationWithUniqueID(uniqueID) {
+                                existingAnnotation.iso639_3Code = iso639_3Code
+                                existingAnnotation.source = source
+                                existingAnnotation.device = device
+                                existingAnnotation.docID = docID
+                                existingAnnotation.docVersion = docVersion
+                                existingAnnotation.created = created
+                                existingAnnotation.lastModified = lastModified
+                                existingAnnotation.status = status
+                                databaseAnnotation = try self.annotationStore.updateAnnotation(existingAnnotation, inSync: true)
                             } else {
-                                try annotationStore.addNote(title: title, content: content, annotationID: annotationID)
+                                databaseAnnotation = try self.annotationStore.addAnnotation(uniqueID: uniqueID, iso639_3Code: iso639_3Code, docID: docID, docVersion: docVersion, created: created, lastModified: lastModified, source: source, device: device, inSync: true)
                             }
-                            downloadNoteCount += 1
-                        } else if let noteID = annotationStore.noteWithAnnotationID(annotationID)?.id {
-                            // The service says that the note has been deleted
+                            self.downloadAnnotationCount += 1
                             
-                            try annotationStore.deleteNoteWithID(noteID)
-                        }
-                        
-                        // MARK: Bookmark
-                        
-                        if let bookmark = rawAnnotation["bookmark"] as? [String: AnyObject] {
-                            do {
-                                if bookmark["@pid"] == nil && bookmark["uri"] != nil {
-                                    // Bookmark has a URI, but no @pid so its invalid. If both are nil, its a valid chapter-level bookmark
-                                    throw Error.errorWithCode(.InvalidParagraphAID, failureReason: "Failed to deserialize bookmark, missing PID: \(bookmark)")
-                                }
+                            if let annotationID = databaseAnnotation?.id, annotationUniqueID = databaseAnnotation?.uniqueID {
                                 
-                                let name = bookmark["name"] as? String
-                                let paragraphAID = bookmark["@pid"] as? String
-                                let displayOrder = bookmark["sort"] as? Int ?? .max
-                                let offset = bookmark["@offset"] as? Int ?? Bookmark.Offset
+                                // MARK: Note
                                 
-                                if var databaseBookmark = annotationStore.bookmarkWithAnnotationID(annotationID) {
-                                    databaseBookmark.name = name
-                                    databaseBookmark.paragraphAID = paragraphAID
-                                    databaseBookmark.displayOrder = displayOrder
-                                    databaseBookmark.offset = offset
+                                if let note = rawAnnotation["note"] as? [String: AnyObject] {
+                                    let title = note["title"] as? String
+                                    let content = note["content"] as? String ?? ""
+                                    if var existingNote = self.annotationStore.noteWithAnnotationID(annotationID) {
+                                        existingNote.title = title
+                                        existingNote.content = content
+                                        try self.annotationStore.updateNote(existingNote)
+                                    } else {
+                                        try self.annotationStore.addNote(title: title, content: content, annotationID: annotationID)
+                                    }
+                                    self.downloadNoteCount += 1
+                                } else if let noteID = self.annotationStore.noteWithAnnotationID(annotationID)?.id {
+                                    // The service says that the note has been deleted
                                     
-                                    try annotationStore.updateBookmark(databaseBookmark)
-                                } else {
-                                    try annotationStore.addBookmark(name: name, paragraphAID: paragraphAID, displayOrder: displayOrder, annotationID: annotationID, offset: offset)
+                                    try self.annotationStore.deleteNoteWithID(noteID)
                                 }
                                 
-                                downloadBookmarkCount += 1
-                            } catch let error as NSError where Error.Code(rawValue: error.code) == .InvalidParagraphAID {
-                                // This will eventually come down from the service correctly once the HTML5 version is available, so just skip it for now
-                                continue
-                            }
-                        } else if let bookmarkID = annotationStore.bookmarkWithAnnotationID(annotationID)?.id {
-                            // The service says that the bookmark has been deleted
-                            
-                            try annotationStore.deleteBookmarkWithID(bookmarkID)
-                        }
-
-                        // MARK: Notebooks
-                        
-                        var notebookIDsToDelete = annotationStore.notebooksWithAnnotationID(annotationID).flatMap { $0.id }
-                        if let folders = rawAnnotation["folders"] as? [String: [[String: AnyObject]]] {
-                            for folder in folders["folder"] ?? [] {
-                                guard let notebookUniqueID = folder["@uri"]?.lastPathComponent else {
-                                    throw Error.errorWithCode(.Unknown, failureReason: "Failed to deserialize notebook: \(folder)")
-                                }
-
-                                guard let notebookID = annotationStore.notebookWithUniqueID(notebookUniqueID)?.id else {
-                                    throw Error.errorWithCode(.Unknown, failureReason: "Cannot find notebook with uniqueID \(notebookUniqueID)")
-                                }
+                                // MARK: Bookmark
                                 
-                                if let index = notebookIDsToDelete.indexOf(notebookID) {
-                                    // This notebook is still connected to the annotation, so remove it from the list of notebook IDs to delete
-                                    notebookIDsToDelete.removeAtIndex(index)
-                                }
-                                
-                                // Don't fail if we don't get a display order from the syncFolders, just put it at the end
-                                let displayOrder = notebookAnnotationIDs[notebookUniqueID]?.indexOf(annotationUniqueID) ?? .max
-
-                                try annotationStore.addOrUpdateAnnotationNotebook(annotationID: annotationID, notebookID: notebookID, displayOrder: displayOrder)
-                            }
-                        }
-                        for notebookID in notebookIDsToDelete {
-                            // Any notebook IDs left in `databaseNotebookIDs` should be deleted because the service says they aren't connected anymore
-                            try annotationStore.deleteAnnotation(annotationID: annotationID, fromNotebook: notebookID)
-                        }
-
-                        // MARK: Highlights
-
-                        // Delete any existing highlights and then we'll just create new ones with what the server gives us
-                        for highlightID in annotationStore.highlightsWithAnnotationID(annotationID).flatMap({ $0.id }) {
-                            try annotationStore.deleteHighlightWithID(highlightID)
-                        }
-                        
-                        // Add new highlights
-                        if let highlights = rawAnnotation["highlights"] as? [String: [[String: AnyObject]]] {
-                            for highlight in highlights["highlight"] ?? [] {
-                                do {
-                                    guard let offsetStartString = highlight["@offset-start"] as? String, offsetStart = Int(offsetStartString), offsetEndString = highlight["@offset-end"] as? String, offsetEnd = Int(offsetEndString), colorName = highlight["@color"] as? String else {
-                                        throw Error.errorWithCode(.InvalidHighlight, failureReason: "Failed to deserialize highlight: \(highlight)")
+                                if let bookmark = rawAnnotation["bookmark"] as? [String: AnyObject] {
+                                    if bookmark["@pid"] == nil && bookmark["uri"] != nil {
+                                        // Bookmark has a URI, but no @pid so its invalid. If both are nil, its a valid chapter-level bookmark
+                                        throw Error.errorWithCode(.InvalidParagraphAID, failureReason: "Failed to deserialize bookmark, missing PID: \(bookmark)")
                                     }
                                     
-                                    guard let paragraphAID = highlight["@pid"] as? String else {
-                                        throw Error.errorWithCode(.InvalidParagraphAID, failureReason: "Failed to deserialize highlight, missing PID: \(highlight)")
-                                    }
-
-                                    let paragraphRange = ParagraphRange(paragraphAID: paragraphAID, startWordOffset: offsetStart, endWordOffset: offsetEnd)
-                                    let style = (highlight["@style"] as? String).flatMap { HighlightStyle(rawValue: $0) } ?? .Highlight
+                                    let name = bookmark["name"] as? String
+                                    let paragraphAID = bookmark["@pid"] as? String
+                                    let displayOrder = bookmark["sort"] as? Int ?? .max
+                                    let offset = bookmark["@offset"] as? Int ?? Bookmark.Offset
                                     
-                                    try annotationStore.addHighlight(paragraphRange: paragraphRange, colorName: colorName, style: style, annotationID: annotationID)
-                                    downloadHighlightCount += 1
+                                    if var databaseBookmark = self.annotationStore.bookmarkWithAnnotationID(annotationID) {
+                                        databaseBookmark.name = name
+                                        databaseBookmark.paragraphAID = paragraphAID
+                                        databaseBookmark.displayOrder = displayOrder
+                                        databaseBookmark.offset = offset
+                                        
+                                        try self.annotationStore.updateBookmark(databaseBookmark)
+                                    } else {
+                                        try self.annotationStore.addBookmark(name: name, paragraphAID: paragraphAID, displayOrder: displayOrder, annotationID: annotationID, offset: offset)
+                                    }
+                                    
+                                    self.downloadBookmarkCount += 1
+                                } else if let bookmarkID = self.annotationStore.bookmarkWithAnnotationID(annotationID)?.id {
+                                    // The service says that the bookmark has been deleted
+                                    
+                                    try self.annotationStore.deleteBookmarkWithID(bookmarkID)
+                                }
                                 
-                                } catch let error as NSError where Error.Code(rawValue: error.code) == .InvalidParagraphAID {
-                                    // This will eventually come down from the service correctly once the HTML5 version is available, so just skip it for now
-                                    continue
+                                // MARK: Notebooks
+                                
+                                var notebookIDsToDelete = self.annotationStore.notebooksWithAnnotationID(annotationID).flatMap { $0.id }
+                                if let folders = rawAnnotation["folders"] as? [String: [[String: AnyObject]]] {
+                                    for folder in folders["folder"] ?? [] {
+                                        guard let notebookUniqueID = folder["@uri"]?.lastPathComponent else {
+                                            throw Error.errorWithCode(.Unknown, failureReason: "Failed to deserialize notebook: \(folder)")
+                                        }
+                                        
+                                        guard let notebookID = self.annotationStore.notebookWithUniqueID(notebookUniqueID)?.id else {
+                                            throw Error.errorWithCode(.Unknown, failureReason: "Cannot find notebook with uniqueID \(notebookUniqueID)")
+                                        }
+                                        
+                                        if let index = notebookIDsToDelete.indexOf(notebookID) {
+                                            // This notebook is still connected to the annotation, so remove it from the list of notebook IDs to delete
+                                            notebookIDsToDelete.removeAtIndex(index)
+                                        }
+                                        
+                                        // Don't fail if we don't get a display order from the syncFolders, just put it at the end
+                                        let displayOrder = self.notebookAnnotationIDs[notebookUniqueID]?.indexOf(annotationUniqueID) ?? .max
+                                        
+                                        try self.annotationStore.addOrUpdateAnnotationNotebook(annotationID: annotationID, notebookID: notebookID, displayOrder: displayOrder)
+                                    }
+                                }
+                                for notebookID in notebookIDsToDelete {
+                                    // Any notebook IDs left in `databaseNotebookIDs` should be deleted because the service says they aren't connected anymore
+                                    try self.annotationStore.deleteAnnotation(annotationID: annotationID, fromNotebook: notebookID)
+                                }
+                                
+                                // MARK: Highlights
+                                
+                                // Delete any existing highlights and then we'll just create new ones with what the server gives us
+                                for highlightID in self.annotationStore.highlightsWithAnnotationID(annotationID).flatMap({ $0.id }) {
+                                    try self.annotationStore.deleteHighlightWithID(highlightID)
+                                }
+                                
+                                // Add new highlights
+                                if let highlights = rawAnnotation["highlights"] as? [String: [[String: AnyObject]]] {
+                                    for highlight in highlights["highlight"] ?? [] {
+                                        guard let offsetStartString = highlight["@offset-start"] as? String, offsetStart = Int(offsetStartString), offsetEndString = highlight["@offset-end"] as? String, offsetEnd = Int(offsetEndString), colorName = highlight["@color"] as? String else {
+                                            throw Error.errorWithCode(.InvalidHighlight, failureReason: "Failed to deserialize highlight: \(highlight)")
+                                        }
+                                        
+                                        guard let paragraphAID = highlight["@pid"] as? String else {
+                                            throw Error.errorWithCode(.InvalidParagraphAID, failureReason: "Failed to deserialize highlight, missing PID: \(highlight)")
+                                        }
+                                        
+                                        let paragraphRange = ParagraphRange(paragraphAID: paragraphAID, startWordOffset: offsetStart, endWordOffset: offsetEnd)
+                                        let style = (highlight["@style"] as? String).flatMap { HighlightStyle(rawValue: $0) } ?? .Highlight
+                                        
+                                        try self.annotationStore.addHighlight(paragraphRange: paragraphRange, colorName: colorName, style: style, annotationID: annotationID)
+                                        self.downloadHighlightCount += 1
+                                    }
+                                }
+                                
+                                // MARK: Links
+                                
+                                // Delete any existing links and then we'll just create new ones with what the server gives us
+                                for linkID in self.annotationStore.linksWithAnnotationID(annotationID).flatMap({ $0.id }) {
+                                    // Any link IDs left in `linksIDsToDelete` should be deleted because the service says they are gone
+                                    try self.annotationStore.deleteLinkWithID(linkID)
+                                }
+                                // Add new links now
+                                if let links = rawAnnotation["refs"] as? [String: [[String: AnyObject]]] {
+                                    for link in links["ref"] ?? [] {
+                                        guard let name = link["$"] as? String else {
+                                            throw Error.errorWithCode(.InvalidLink, failureReason: "Failed to deserialize link: \(link)")
+                                        }
+                                        
+                                        guard let paragraphAIDs = link["@pid"] as? String, docID = link["@docId"] as? String, docVersionString = link["@contentVersion"] as? String, docVersion = Int(docVersionString) else {
+                                            throw Error.errorWithCode(.InvalidParagraphAID, failureReason: "Failed to deserialize link, missing PID: \(link)")
+                                        }
+                                        
+                                        try self.annotationStore.addLink(name: name, docID: docID, docVersion: docVersion, paragraphAIDs: paragraphAIDs.componentsSeparatedByString(",").map { $0.trimmed() }, annotationID: annotationID)
+                                        self.downloadLinkCount += 1
+                                    }
+                                }
+                                
+                                // MARK: Tags
+                                
+                                // Remove any existings tags from the annotation and then we'll re-added what the server sends us
+                                for tagID in self.annotationStore.tagsWithAnnotationID(annotationID).flatMap({ $0.id }) {
+                                    try self.annotationStore.deleteTag(tagID: tagID, fromAnnotation: annotationID)
+                                }
+                                if let tags = rawAnnotation["tags"] as? [String: [String]] {
+                                    for tagName in tags["tag"] ?? [] {
+                                        try self.annotationStore.addTag(name: tagName, annotationID: annotationID)
+                                        self.downloadTagCount += 1
+                                    }
                                 }
                             }
                         }
+                    } catch {
+                        // Failed to deserialize this annotation, instead of failing the entire sync, just skip this annotation, and keep track of the error in case the client wants to do something with the errors
                         
-                        // MARK: Links
+                        let annotationData = try? NSJSONSerialization.dataWithJSONObject(rawAnnotation, options: .PrettyPrinted)
+                        let annotationString = annotationData.flatMap { String(data: $0, encoding: NSUTF8StringEncoding) }
                         
-                        // Delete any existing links and then we'll just create new ones with what the server gives us
-                        for linkID in annotationStore.linksWithAnnotationID(annotationID).flatMap({ $0.id }) {
-                            // Any link IDs left in `linksIDsToDelete` should be deleted because the service says they are gone
-                            try annotationStore.deleteLinkWithID(linkID)
-                        }
-                        // Add new links now
-                        if let links = rawAnnotation["refs"] as? [String: [[String: AnyObject]]] {
-                            for link in links["ref"] ?? [] {
-                                do {
-                                    guard let name = link["$"] as? String else {
-                                        throw Error.errorWithCode(.InvalidLink, failureReason: "Failed to deserialize link: \(link)")
-                                    }
-                                    
-                                    guard let paragraphAIDs = link["@pid"] as? String, docID = link["@docId"] as? String, docVersionString = link["@contentVersion"] as? String, docVersion = Int(docVersionString) else {
-                                        throw Error.errorWithCode(.InvalidParagraphAID, failureReason: "Failed to deserialize link, missing PID: \(link)")
-                                    }
-                                    
-                                    try annotationStore.addLink(name: name, docID: docID, docVersion: docVersion, paragraphAIDs: paragraphAIDs.componentsSeparatedByString(",").map { $0.trimmed() }, annotationID: annotationID)
-                                    downloadLinkCount += 1
-                                    
-                                } catch let error as NSError where Error.Code(rawValue: error.code) == .InvalidParagraphAID {
-                                    // This will eventually come down from the service correctly once the HTML5 version is available, so just skip it for now
-                                    continue
-                                }
-                            }
-                        }
-                        
-                        // MARK: Tags
-                        
-                        // Remove any existings tags from the annotation and then we'll re-added what the server sends us
-                        for tagID in annotationStore.tagsWithAnnotationID(annotationID).flatMap({ $0.id }) {
-                            try annotationStore.deleteTag(tagID: tagID, fromAnnotation: annotationID)
-                        }
-                        if let tags = rawAnnotation["tags"] as? [String: [String]] {
-                            for tagName in tags["tag"] ?? [] {
-                                try annotationStore.addTag(name: tagName, annotationID: annotationID)
-                                downloadTagCount += 1
-                            }
-                        }
+                        let error = Error.errorWithCode(.SyncDeserializationFailed, failureReason: String(format: "Unable to deserialize annotation: %@", annotationString ?? rawAnnotation))
+                        deserializationErrors.append(error)
                     }
                 case .Trash, .Delete:
                     if let existingAnnotationID = annotationStore.annotationWithUniqueID(uniqueID)?.id {

--- a/LDSAnnotations/SyncAnnotationsResult.swift
+++ b/LDSAnnotations/SyncAnnotationsResult.swift
@@ -24,7 +24,7 @@ import Foundation
 
 enum SyncAnnotationsResult {
     
-    case Success(localSyncAnnotationsDate: NSDate, serverSyncAnnotationsDate: NSDate, changes: SyncAnnotationsChanges)
+    case Success(localSyncAnnotationsDate: NSDate, serverSyncAnnotationsDate: NSDate, changes: SyncAnnotationsChanges, deserializationErrors: [NSError])
     case Error(errors: [NSError])
     
 }

--- a/LDSAnnotations/SyncNotebooksResult.swift
+++ b/LDSAnnotations/SyncNotebooksResult.swift
@@ -24,7 +24,7 @@ import Foundation
 
 enum SyncNotebooksResult {
 
-    case Success(localSyncNotebooksDate: NSDate, serverSyncNotebooksDate: NSDate, changes: SyncNotebooksChanges)
+    case Success(localSyncNotebooksDate: NSDate, serverSyncNotebooksDate: NSDate, changes: SyncNotebooksChanges, deserializationErrors: [NSError])
     case Error(errors: [NSError])
 
 }

--- a/LDSAnnotations/SyncResult.swift
+++ b/LDSAnnotations/SyncResult.swift
@@ -28,7 +28,7 @@ public enum SyncResult {
     /// Result when sync is successful.
     ///
     /// The `token` should be used for the next sync.
-    case Success(token: SyncToken, changes: SyncChanges)
+    case Success(token: SyncToken, changes: SyncChanges, deserializationErrors: [NSError])
     
     /// Result when a sync fails.
     case Error(errors: [NSError])

--- a/LDSAnnotationsDemo/AccountViewController.swift
+++ b/LDSAnnotationsDemo/AccountViewController.swift
@@ -145,7 +145,7 @@ class AccountViewController: UIViewController {
         session.sync(annotationStore: annotationStore, token: token) { syncResult in
             dispatch_sync(dispatch_get_main_queue()) {
                 switch syncResult {
-                case let .Success(token: token, changes: changes):
+                case let .Success(token: token, changes: changes, deserializationErrors: deserializationErrors):
                     let uploaded = [
                         "\(changes.uploadedNotebooks.count) notebooks",
                         "\(changes.uploadAnnotationCount) annotations",
@@ -166,6 +166,8 @@ class AccountViewController: UIViewController {
                     ]
                     
                     NSLog("Sync completed:\n    Uploaded: %@\n    Downloaded: %@", uploaded.joinWithSeparator(", "), downloaded.joinWithSeparator(", "))
+                    
+                    deserializationErrors.forEach { NSLog("%@", $0) }
                     
                     AccountController.sharedController.setSyncToken(token, forUsername: self.session.username)
                 case let .Error(errors: errors):

--- a/LDSAnnotationsTests/BookmarkTests.swift
+++ b/LDSAnnotationsTests/BookmarkTests.swift
@@ -38,8 +38,6 @@ class BookmarkTests: XCTestCase {
         
         do {
             try operation.applyServerChanges(payloadForBookmark(bookmark), onOrBefore: NSDate())
-        } catch let error as NSError where Error.Code(rawValue: error.code) == .InvalidParagraphAID {
-            XCTFail("We don't expect this error to be thrown, we expect this bookmark to just be skipped")
         } catch {
             XCTFail("Unexpected error: \(error)")
         }

--- a/LDSAnnotationsTests/HighlightTests.swift
+++ b/LDSAnnotationsTests/HighlightTests.swift
@@ -39,8 +39,6 @@ class HighlightTests: XCTestCase {
         
         do {
             try operation.applyServerChanges(payloadForHighlight(highlight), onOrBefore: NSDate())
-        } catch let error as NSError where Error.Code(rawValue: error.code) == .InvalidParagraphAID {
-            XCTFail("Don't expect this error to be thrown, the highlight should just have been skipped")
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
@@ -61,7 +59,6 @@ class HighlightTests: XCTestCase {
         
         do {
             try operation.applyServerChanges(payloadForHighlight(highlight), onOrBefore: NSDate())
-        } catch let error as NSError where Error.Code(rawValue: error.code) == .InvalidHighlight {
         } catch {
             XCTFail("Unexpected error: \(error)")
         }

--- a/LDSAnnotationsTests/LinkTests.swift
+++ b/LDSAnnotationsTests/LinkTests.swift
@@ -38,8 +38,6 @@ class LinkTests: XCTestCase {
         
         do {
             try syncAnnotationsOperation.applyServerChanges(payloadForLink(link), onOrBefore: NSDate())
-        } catch let error as NSError where Error.Code(rawValue: error.code) == .InvalidParagraphAID {
-            XCTFail("The link shouldn't fail if the @pid is mising, it should just be skipped")
         } catch {
             XCTFail("Unexpected error: \(error)")
         }

--- a/LDSAnnotationsTests/XCTestCase+LDSAnnotations.swift
+++ b/LDSAnnotationsTests/XCTestCase+LDSAnnotations.swift
@@ -53,7 +53,7 @@ extension XCTestCase {
         let expectation = expectationWithDescription(description)
         session.sync(annotationStore: annotationStore, token: token) { syncResult in
             switch syncResult {
-            case let .Success(token: newToken, changes: changes):
+            case let .Success(token: newToken, changes: changes, deserializationErrors: _):
                 token = newToken
                 
                 completion?(uploadCount: changes.uploadedNotebooks.count + changes.uploadAnnotationCount, downloadCount: changes.downloadedNotebooks.count + changes.downloadAnnotationCount)


### PR DESCRIPTION
Before we we skipping just pieces of the annotation. For example, if the highlight didn't have a @pid, we just skipped the highlight, but did save the annotation and any notes in the db. That's not what we want though, because it lets us change the annotation. If an annotation is invalid (which should in pretty much all cases be from it not being updated for HTML5), we just skip that annotation. When HTML5 becomes available for that annotation, it will come down from the service as a change and be valid and saved. 