### PR TITLE
Add function to get annotation IDs associated with doc IDs.

### DIFF
--- a/LDSAnnotations/AnnotationStore+Annotation.swift
+++ b/LDSAnnotations/AnnotationStore+Annotation.swift
@@ -108,7 +108,7 @@ public extension AnnotationStore {
     /// Returns all annotation IDs associated with the given docIDs
     public func annotationIDsWithDocIDsIn(docIDs: [String]) -> [Int64] {
         do {
-            return try db.prepare(AnnotationTable.table.filter(docIDs.contains(AnnotationTable.docID))).map { $0[AnnotationTable.id] }
+            return try db.prepare(AnnotationTable.table.filter(docIDs.contains(AnnotationTable.docID)).filter(AnnotationTable.status == .Active)).map { $0[AnnotationTable.id] }
         } catch {
             return []
         }
@@ -135,7 +135,7 @@ public extension AnnotationStore {
     /// Returns a list of active annotation IDs for active annotations associated with tagID, ordered by last modified descending
     public func annotationIDs(limit limit: Int? = nil) -> [Int64] {
         do {
-            var query = AnnotationTable.table.select(AnnotationTable.id, AnnotationTable.status, AnnotationTable.lastModified).filter(AnnotationTable.status == .Active).order(AnnotationTable.lastModified)
+            var query = AnnotationTable.table.select(AnnotationTable.id).filter(AnnotationTable.status == .Active).order(AnnotationTable.lastModified)
             if let limit = limit {
                 query = query.limit(limit)
             }
@@ -148,7 +148,7 @@ public extension AnnotationStore {
     /// Returns a list of active annotation IDs for active annotations associated with tagID, ordered by last modified descending
     public func annotationIDsWithLastModified() -> [(Int64, NSDate)] {
         do {
-            var query = AnnotationTable.table.select(AnnotationTable.id, AnnotationTable.status, AnnotationTable.lastModified).filter(AnnotationTable.status == .Active).order(AnnotationTable.lastModified)
+            let query = AnnotationTable.table.select(AnnotationTable.id, AnnotationTable.lastModified).filter(AnnotationTable.status == .Active).order(AnnotationTable.lastModified)
             return try db.prepare(query).map { ($0[AnnotationTable.id], $0[AnnotationTable.lastModified]) }
         } catch {
             return []

--- a/LDSAnnotations/AnnotationStore+Annotation.swift
+++ b/LDSAnnotations/AnnotationStore+Annotation.swift
@@ -105,6 +105,15 @@ public extension AnnotationStore {
         }
     }
     
+    /// Returns all annotation IDs associated with the given docIDs
+    public func annotationIDsWithDocIDsIn(docIDs: [String]) -> [Int64] {
+        do {
+            return try db.prepare(AnnotationTable.table.filter(docIDs.contains(AnnotationTable.docID))).map { $0[AnnotationTable.id] }
+        } catch {
+            return []
+        }
+    }
+    
     /// Returns a list of active annotation IDs associated with notebookID, ordered by display order
     public func annotationIDsForNotebookWithID(notebookID: Int64) -> [Int64] {
         do {
@@ -131,6 +140,16 @@ public extension AnnotationStore {
                 query = query.limit(limit)
             }
             return try db.prepare(query).map { $0[AnnotationTable.id] }
+        } catch {
+            return []
+        }
+    }
+    
+    /// Returns a list of active annotation IDs for active annotations associated with tagID, ordered by last modified descending
+    public func annotationIDsWithLastModified() -> [(Int64, NSDate)] {
+        do {
+            var query = AnnotationTable.table.select(AnnotationTable.id, AnnotationTable.status, AnnotationTable.lastModified).filter(AnnotationTable.status == .Active).order(AnnotationTable.lastModified)
+            return try db.prepare(query).map { ($0[AnnotationTable.id], $0[AnnotationTable.lastModified]) }
         } catch {
             return []
         }

--- a/LDSAnnotations/AnnotationStore+Annotation.swift
+++ b/LDSAnnotations/AnnotationStore+Annotation.swift
@@ -108,7 +108,7 @@ public extension AnnotationStore {
     /// Returns all annotation IDs associated with the given docIDs
     public func annotationIDsWithDocIDsIn(docIDs: [String]) -> [Int64] {
         do {
-            return try db.prepare(AnnotationTable.table.filter(docIDs.contains(AnnotationTable.docID)).filter(AnnotationTable.status == .Active)).map { $0[AnnotationTable.id] }
+            return try db.prepare(AnnotationTable.table.select(AnnotationTable.id).filter(docIDs.contains(AnnotationTable.docID)).filter(AnnotationTable.status == .Active)).map { $0[AnnotationTable.id] }
         } catch {
             return []
         }

--- a/LDSAnnotationsTests/AnnotationStoreTests.swift
+++ b/LDSAnnotationsTests/AnnotationStoreTests.swift
@@ -442,6 +442,23 @@ class AnnotationStoreTests: XCTestCase {
         for limit in [1, 5, 10, 15, 20] {
             XCTAssertEqual(limit, annotationStore.annotationIDs(limit: limit).count, "Didn't load correct number of annotation IDs for notebook")
         }
+        
+        for i in 0..<10 {
+            try! annotationStore.trashAnnotationWithID(annotations[i].id)
+        }
+        XCTAssertEqual(10, annotationStore.annotationIDs(limit: 20).count)
+    }
+    
+    func testGetAnnotationIDsWithLastModified() {
+        let annotationStore = AnnotationStore()!
+        
+        var annotations = [Annotation]()
+        for _ in 0..<20 {
+            annotations.append(try! annotationStore.addAnnotation(docID: "13859831", docVersion: 1, appSource: "Test", device: "iphone", source: .Local))
+        }
+        
+        let idsAndModified = annotationStore.annotationIDsWithLastModified()
+        XCTAssertEqual(idsAndModified.count, 20)
     }
     
     func testGetAnnotationsLinkedToDocID() {

--- a/LDSAnnotationsTests/AnnotationStoreTests.swift
+++ b/LDSAnnotationsTests/AnnotationStoreTests.swift
@@ -375,6 +375,22 @@ class AnnotationStoreTests: XCTestCase {
         XCTAssertEqual([annotation!], annotationStore.annotations(docID: docID, paragraphAIDs: paragraphRanges.map({ $0.paragraphAID })))
     }
     
+    func testGetAnnotationIDsWithDocIDs() {
+        let annotationStore = AnnotationStore()!
+        
+        let docID1 = "1"
+        let docID2 = "2"
+        let docID3 = "3"
+        
+        let annotations = [
+            try! annotationStore.addAnnotation(docID: docID1, docVersion: 1, appSource: "Test", device: "iphone", source: .Local),
+            try! annotationStore.addAnnotation(docID: docID2, docVersion: 1, appSource: "Test", device: "iphone", source: .Local)
+        ]
+        try! annotationStore.addAnnotation(docID: docID3, docVersion: 1, appSource: "Test", device: "iphone", source: .Local)
+        
+        XCTAssertEqual(Set(annotations.map({ $0.id })), Set(annotationStore.annotationIDsWithDocIDsIn([docID1, docID2])))
+    }
+    
     func testGetAnnotationIDsForNotebook() {
         let annotationStore = AnnotationStore()!
         


### PR DESCRIPTION
The main purpose of this method is to get all annotations associated with an item.