### PR TITLE
Have addAll reset lastModified so sync will pick them up.

### DIFF
--- a/LDSAnnotations/AnnotationStore+Merge.swift
+++ b/LDSAnnotations/AnnotationStore+Merge.swift
@@ -14,7 +14,7 @@ extension AnnotationStore {
         let notebooks = otherStore.notebooks()
         for notebook in notebooks {
             do {
-                try addNotebook(uniqueID: notebook.uniqueID, name: notebook.name, description: notebook.description, status: notebook.status, lastModified: notebook.lastModified, source: .sync)
+                try addNotebook(uniqueID: notebook.uniqueID, name: notebook.name, description: notebook.description, status: notebook.status, source: .local)
             } catch {
                 NSLog("Unable to add notebook: \(error)")
             }
@@ -22,12 +22,12 @@ extension AnnotationStore {
         
         for annotation in otherStore.annotations() {
             do {
-                let newAnnotation = try addAnnotation(uniqueID: annotation.uniqueID, docID: annotation.docID, docVersion: annotation.docVersion, status: annotation.status, created: annotation.created, lastModified: annotation.lastModified, appSource: appSource, device: device, source: .sync)
+                let newAnnotation = try addAnnotation(uniqueID: annotation.uniqueID, docID: annotation.docID, docVersion: annotation.docVersion, status: annotation.status, created: annotation.created, appSource: appSource, device: device, source: .local)
                 if let note = otherStore.noteWithAnnotationID(annotation.id) {
                     try addNote(title: note.title, content: note.content, annotationID: newAnnotation.id)
                 }
                 for highlight in otherStore.highlightsWithAnnotationID(annotation.id) {
-                    try addHighlight(paragraphRange: highlight.paragraphRange, colorName: highlight.colorName, style: highlight.style, annotationID: newAnnotation.id, source: .sync)
+                    try addHighlight(paragraphRange: highlight.paragraphRange, colorName: highlight.colorName, style: highlight.style, annotationID: newAnnotation.id, source: .local)
                 }
                 for tag in otherStore.tagsWithAnnotationID(annotation.id) {
                     try addTag(name: tag.name, annotationID: newAnnotation.id)
@@ -36,7 +36,7 @@ extension AnnotationStore {
                     try addLink(name: link.name, toDocID: link.docID, toDocVersion: link.docVersion, toParagraphAIDs: link.paragraphAIDs, annotationID: newAnnotation.id)
                 }
                 if let bookmark = otherStore.bookmarkWithAnnotationID(annotation.id) {
-                    try addBookmark(name: bookmark.name, paragraphAID: bookmark.paragraphAID, displayOrder: bookmark.displayOrder, annotationID: newAnnotation.id, offset: bookmark.offset, source: .sync)
+                    try addBookmark(name: bookmark.name, paragraphAID: bookmark.paragraphAID, displayOrder: bookmark.displayOrder, annotationID: newAnnotation.id, offset: bookmark.offset, source: .local)
                 }
                 for notebook in otherStore.notebooksWithAnnotationID(annotation.id) {
                     if let newNotebook = notebookWithUniqueID(notebook.uniqueID) {

--- a/LDSAnnotationsTests/AnnotationStoreMergeTests.swift
+++ b/LDSAnnotationsTests/AnnotationStoreMergeTests.swift
@@ -72,8 +72,8 @@ class AnnotationStoreMergeTests: XCTestCase {
         let otherStore = AnnotationStore()!
         otherStore.addAll(from: annotationStore, appSource: "Test", device: "iphone")
         
-        XCTAssertEqual([annotation!], otherStore.annotations(paragraphAIDs: paragraphRanges.map({ $0.paragraphAID })))
-        XCTAssertEqual([annotation!], otherStore.annotations(docID: docID, paragraphAIDs: paragraphRanges.map({ $0.paragraphAID })))
+        verifyEqualBesidesLastModified(annotation1: annotation!, annotation2: otherStore.annotations(paragraphAIDs: paragraphRanges.map({ $0.paragraphAID })).first!)
+        verifyEqualBesidesLastModified(annotation1: annotation!, annotation2: otherStore.annotations(docID: docID, paragraphAIDs: paragraphRanges.map({ $0.paragraphAID })).first!)
     }
     
     func testMergeNotebook() {
@@ -128,6 +128,17 @@ class AnnotationStoreMergeTests: XCTestCase {
             
             XCTAssertTrue(Set(annotationUniqueIDs) == Set(otherUniqueIDs), "Didn't load correct annotations for tagID")
         }
+    }
+    
+    fileprivate func verifyEqualBesidesLastModified(annotation1: Annotation, annotation2: Annotation) {
+        XCTAssertEqual(annotation1.id, annotation2.id)
+        XCTAssertEqual(annotation1.uniqueID, annotation2.uniqueID)
+        XCTAssertEqual(annotation1.docID, annotation2.docID)
+        XCTAssertEqual(annotation1.docVersion, annotation2.docVersion)
+        XCTAssertEqual(annotation1.status, annotation2.status)
+        XCTAssertEqual(annotation1.created, annotation2.created)
+        XCTAssertEqual(annotation1.appSource, annotation2.appSource)
+        XCTAssertEqual(annotation1.device, annotation2.device)
     }
     
 }


### PR DESCRIPTION
This isn't the ideal solution, but it's the simplest, and given the rarity of the merge annotations situation we felt like simple was better than "correct."